### PR TITLE
Drop support for Python versions older than 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     defaults:
       run:
         shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ Resources
 * Running Checkers for Praktomat with docker: https://github.com/hso-praktomat/praktomat-checkers
 * Moderated [mailing list] for Praktomat administrators: praktomat-users@lists.kit.edu.
 
-Python 3.5
+Python 3.8
 ==========
-  The Praktomat currently requires Python 3.5
+  The Praktomat currently requires at least Python 3.8. Older versions of Python may or may not work. Use them at your own risk.
 
-  On Ubuntu 16.04, Python3.5 is installed by default,
-  but you may need to install the packages
+  On Ubuntu 22.04, Python 3.10 is available by default,
+  but you may need to additionaly install the packages
 
-    python-setuptools
-    python-psycopg2
-    python-virtualenv
+    python3-setuptools
+    python3-psycopg2
+    python3-virtualenv
 
 
 General setup

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
 urllib3[secure]
 # workaround for debug-toolbar/sqlparse incompatibility, see http://stackoverflow.com/questions/38479063/django-debug-toolbar-breaking-on-admin-while-getting-sql-stats
 sqlparse
-Django~=2.0;python_version=="3.4"
 Django~=2.2;python_version>="3.5"
-django-admin-view-permission;python_version<="3.4"
 # M2Crypto # has been removed by commit "use hashlib+smime for upload verification mails instead of M2Crypto" (19.1.2018)
 Markdown
 Pygments~=2.7.0;python_version>="3.4"
@@ -13,13 +11,10 @@ django-extensions
 # It appears that due to the pull-request https://github.com/aljosa/django-tinymce/pull/103 merged in django-tinymce==2.4.0, jquery is loaded after our onw jquery
 # loaded in admin-sites. Using an old version of django-tinymce (2.3.x) is not possible because it uses methods removed between Django 1.8 and 1.11.
 # We might want to use the django-admin provieded jquery in our admin-site jquery snippets?!?!?
-django-tinymce~=2.8;python_version<="3.5"  # because 3.0.1 and 3.0.2 gave error messages with python 3.5 and lower
 django-tinymce~=3.0;python_version>="3.6"
 django-debug-toolbar
 docutils
 psycopg2-binary
-subprocess32;python_version<"3"
-pathlib;python_version<"3"
 # selenium # has been removed by commit "remove selenium and phantomjs dependency" (16.1.2020)
 
 #modules used in fix bug #255 in safeexec.py


### PR DESCRIPTION
Although Python 3.7 still receives security updates, its support is going to end soon (June 2023). Also, if we want to upgrade to Django 4, Python 3.8 will be the minimum required version anyway. 