### PR TITLE
GitHub Actions: also run tests for Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
Meanwhile, Python 3.11 is available through the main Anaconda channel, so we should also run our unit tests for that version.

I was unable, though, to run a real Praktomat instance with Python 3.11 as there is no Ubuntu version yet that ships this version of Python. I'm just assuming that it works. If there turns out to be a problem, we can fix it later.