### PR TITLE
Allow solution downloads for superusers

### DIFF
--- a/src/solutions/views.py
+++ b/src/solutions/views.py
@@ -269,7 +269,7 @@ def solution_download(request, solution_id, include_checker_files, include_artif
     allowed_tutor = request.user.is_tutor and solution.author.tutorial in request.user.tutored_tutorials.all()
     allowed_user = solution.author == request.user and not include_checker_files and not include_artifacts
     hide = request.user.is_user and get_settings().hide_solutions_of_expired_tasks and solution.task.expired()
-    if not (request.user.is_trainer or allowed_tutor or allowed_user) or hide:
+    if not (request.user.is_superuser or request.user.is_trainer or allowed_tutor or allowed_user) or hide:
         return access_denied(request)
 
     zip_file = get_solutions_zip([solution], include_checker_files, include_artifacts)
@@ -279,7 +279,7 @@ def solution_download(request, solution_id, include_checker_files, include_artif
 
 @login_required
 def solution_download_for_task(request, task_id, include_checker_files, include_artifacts):
-    if not (request.user.is_tutor or request.user.is_trainer):
+    if not (request.user.is_tutor or request.user.is_trainer or request.user.is_superuser):
         return access_denied(request)
 
     task = get_object_or_404(Task, pk=task_id)


### PR DESCRIPTION
This allows superusers to download solutions (e.g. to reproduce errors of the Praktomat). Otherwise, you'd need to add the trainer role to the superuser first in order to get access, which is mildly inconvenient.