### PR TITLE
Show media files under a task's description

### DIFF
--- a/src/tasks/models.py
+++ b/src/tasks/models.py
@@ -140,6 +140,9 @@ class Task(models.Model):
             self.jplag_up_to_date = False
             self.save()
 
+    def media_files(self):
+        return MediaFile.objects.filter(task=self)
+
     @staticmethod
     def jplag_languages():
         return { 'Java':     { 'param': 'java19', 'files': '.java,.JAVA' },
@@ -367,6 +370,11 @@ class MediaFile(models.Model):
 
     task = models.ForeignKey(Task, on_delete=models.CASCADE)
     media_file = DeletingFileField(upload_to=get_mediafile_storage_path, max_length=500)
+
+    def basename(self):
+        name = self.media_file.name
+        i = name.rfind("/") + 1
+        return name[i:]
 
 
 class HtmlInjector(models.Model):

--- a/src/templates/attestation/attestation_edit.html
+++ b/src/templates/attestation/attestation_edit.html
@@ -114,6 +114,15 @@
 		<div id="task">
 			<h1 class="heading">Task</h1>
 			{{solution.task.description|safe}}
+
+			{% if solution.task.media_files|length > 0 %}
+			<h3>Files</h3>
+			<ul>
+			{% for file in solution.task.media_files %}
+				<li><a href="{{ file.media_file.url }}">{{ file.basename }}</a></li>
+			{% endfor %}
+			</ul>
+			{% endif %}
 		</div>
 
 		{% if model_solution %}

--- a/src/templates/tasks/task_detail.html
+++ b/src/templates/tasks/task_detail.html
@@ -27,4 +27,13 @@
 </p>
 {{task.description|safe}}
 
+{% if task.media_files|length > 0 %}
+<h3>Files</h3>
+<ul>
+{% for file in task.media_files %}
+	<li><a href="{{ file.media_file.url }}">{{ file.basename }}</a></li>
+{% endfor %}
+</ul>
+{% endif %}
+
 <div>{% endblock %}


### PR DESCRIPTION
Uploading files for a task was already possible. The problem was that these files were not automatically displayed in the detail view of a task.

With this change, a list of files will be displayed underneath a task's description, so students can download them. If no media files are present, this section will be hidden. The displayed name is just the file name. That probably makes sense as this information is already available and I don't need to modify the task's model. Also, students know for what file name to search for in their Downloads directory.

Closes #32