### PR TITLE
Drop support for Apache httpd 2.2

### DIFF
--- a/documentation/apache_praktomat_wsgi.conf
+++ b/documentation/apache_praktomat_wsgi.conf
@@ -35,16 +35,7 @@
 
     # The installation directory
     <Directory $path/Praktomat/>
-                # Apache 2.2
-                <IfVersion < 2.4>
-                 Order allow,deny
-                 allow from all
-                </IfVersion>
-
-                # Apache 2.4
-                <IfVersion >= 2.4>
-                 Require all granted
-                </IfVersion>
+        Require all granted
     </Directory>
 
     # Depending on the version of apache(?), the following might be necessary
@@ -58,29 +49,11 @@
     </Location>
 
     <Directory $path/static/>
-                # Apache 2.2
-                <IfVersion < 2.4>
-                 Order allow,deny
-                 allow from all
-                </IfVersion>
-
-                # Apache 2.4
-                <IfVersion >= 2.4>
-                 Require all granted
-                </IfVersion>
+        Require all granted
     </Directory>
 
     <Directory $path/work-data/>
-               # Apache 2.2
-                <IfVersion < 2.4>
-                 Order allow,deny
-                 allow from all
-                </IfVersion>
-
-                # Apache 2.4
-                <IfVersion >= 2.4>
-                 Require all granted
-                </IfVersion>
+        Require all granted
     </Directory>
 
    # RH: try, but not work as I think: https://github.com/johnsensible/django-sendfile


### PR DESCRIPTION
Version 2.2 went end of life back in 2017. There's no sane reason to keep this in the configuration example.