### PR TITLE
Allow to import tutorial assignments with usernames

### DIFF
--- a/src/accounts/forms.py
+++ b/src/accounts/forms.py
@@ -164,12 +164,19 @@ class ImportLDAPForm(forms.Form):
     uids = forms.CharField(label='UIDs', required=False, widget=forms.Textarea, initial = '', help_text = "List of UIDs to be imported, delimited by whitespace. Already existing accounts will be ignored.")
 
 
+IMPORT_TUTORIAL_ASSIGNMENT_TYPES = (
+    ("mat_number", "Matriculation number"),
+    ("username", "Username"),
+)
+
+
 class ImportTutorialAssignmentForm(forms.Form):
-    csv_file = forms.FileField(required=True, help_text = "The csv file containing the tutorial name and the students' mat number.")
+    csv_file = forms.FileField(required=True, help_text = "The csv file containing the tutorial name and the students' mat number or username.")
     delimiter = forms.CharField(required=True, max_length = 1, initial = ";", help_text = "A one-character string used to separate fields.")
     quotechar = forms.CharField(required=True, max_length = 1, initial = "|", help_text = "A one-character string used to quote fields.")
-    name_coloum = forms.IntegerField(required=True, initial = 0, help_text = "The index of the field containing the name of the tutorial.")
-    mat_coloum = forms.IntegerField(required=True, initial = 1, help_text = "The index of the field containing the mat number of the user.")
+    name_column = forms.IntegerField(required=True, initial = 0, help_text = "The index of the field containing the name of the tutorial.")
+    user_id_column = forms.IntegerField(required=True, initial = 1, help_text = "The index of the field containing the mat number or username of the user.")
+    user_id_type = forms.ChoiceField(required=True, choices = IMPORT_TUTORIAL_ASSIGNMENT_TYPES, initial = "mat_number", help_text = "The type of user identification.")
 
 class ImportUserTextsForm(forms.Form):
     csv_file = forms.FileField(required=True, help_text = "The csv file containing the tutorial name and the students' mat number.")

--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -170,14 +170,20 @@ def import_tutorial_assignment(request):
                 messages.error(request, "Import failed: %s" % str(e))
                 return render(request, 'admin/accounts/user/import_tutorial_assignment.html', {'form': form, 'title':"Import tutorial assignment"  })
             succeeded = not_present = failed = 0
+            user_id_column = form.cleaned_data['user_id_column']
             for row in reader:
                 try:
-                    matching_users = User.objects.filter(mat_number = row[form.cleaned_data['mat_coloum']])
+                    user_id_type = form.cleaned_data['user_id_type']
+                    user_id_value = row[user_id_column]
+                    if user_id_type == 'mat_number':
+                        matching_users = User.objects.filter(mat_number = user_id_value)
+                    elif user_id_type == 'username':
+                        matching_users = User.objects.filter(username = user_id_value)
                     if not matching_users.exists():
                         not_present += 1
                         continue
                     user = matching_users.get()
-                    tutorial = Tutorial.objects.get(name = row[form.cleaned_data['name_coloum']])
+                    tutorial = Tutorial.objects.get(name = row[form.cleaned_data['name_column']])
                     user.tutorial = tutorial
                     user.save()
                     succeeded += 1


### PR DESCRIPTION
This adds a dropdown menu to the "Import tutorial assignments" form that allows you to select how students are identified (matriculation number or username). It still defaults to matriculation number but using usernames in the CSV file is now supported as well.

Closes #25