### PR TITLE
Update Pygments to 2.16.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ sqlparse
 Django~=2.2;python_version>="3.5"
 # M2Crypto # has been removed by commit "use hashlib+smime for upload verification mails instead of M2Crypto" (19.1.2018)
 Markdown
-Pygments~=2.7.0;python_version>="3.4"
+Pygments~=2.16.1
 chardet
 django-extensions
 


### PR DESCRIPTION
This updates Pygments to 2.16.1. We'll get an updated syntax highlighting that supports "new" language features such as Records in Java.

The version is still pinned to avoid a sudden breakage due to the hack where the IsarLexer is inserted into the available lexers.