### PR TITLE
Remove old unused JUNIT38 setting

### DIFF
--- a/src/checker/compiler/JavaBuilder.py
+++ b/src/checker/compiler/JavaBuilder.py
@@ -53,11 +53,6 @@ class JavaBuilder(ClassFileGeneratingBuilder):
     _env['JAVAP'] = settings.JAVAP
 
     def libs(self):
-        def toPath(lib):
-            if lib=="junit3":
-                return settings.JUNIT38_JAR
-            return lib
-
         required_libs = super(JavaBuilder, self).libs()
 
         return ["-cp", ".:"+(":".join([ settings.JAVA_LIBS[lib] for lib in required_libs if lib in settings.JAVA_LIBS ]))]

--- a/src/settings/defaults.py
+++ b/src/settings/defaults.py
@@ -274,7 +274,6 @@ def load_defaults(settings):
     d.ISABELLE_BINARY = 'isabelle' # Isabelle should be in PATH
     d.DEJAGNU_RUNTEST = '/usr/bin/runtest'
     d.CHECKSTYLEALLJAR = '/home/praktomat/contrib/checkstyle-8.14-all.jar'
-    d.JUNIT38='junit'
     d.JAVA_LIBS = { 'jun' : '/usr/share/java/junit.jar', 'junit4' : '/usr/share/java/junit4.jar' }
     d.JAVA_CUSTOM_LIBS = PRAKTOMAT_ROOT + '/lib/java/*'
     d.JCFDUMP='jcf-dump'


### PR DESCRIPTION
This setting is no longer used and can safely be removed.