### PR TITLE
Use application/octet-stream as a fallback mime type

### DIFF
--- a/src/solutions/forms.py
+++ b/src/solutions/forms.py
@@ -3,9 +3,8 @@
 from django.utils.translation import ugettext_lazy as _
 from django.forms.models import ModelForm, inlineformset_factory, BaseInlineFormSet
 from django import forms
-from django.conf import settings
 import zipfile
-import mimetypes
+from utilities.mimetypes import guess_mime_type_with_fallback as guess_mime_type
 import re
 
 from solutions.models import Solution, SolutionFile
@@ -14,9 +13,6 @@ from functools import reduce
 
 ziptype_re = re.compile(r'^application/(zip|x-zip|x-zip-compressed|x-compressed)$')
 tartype_re = re.compile(r'^application/(tar|x-tar|x-tar-compressed)$')
-
-for (mimetype, extension) in settings.MIMETYPE_ADDITIONAL_EXTENSIONS:
-    mimetypes.add_type(mimetype, extension, strict=True)
 
 def contains_NUL_char(bytestring):
     return encoding.get_unicode(bytestring).find("\x00") >= 0
@@ -32,7 +28,7 @@ class SolutionFileForm(ModelForm):
         max_file_size_kib = task.max_file_size
         max_file_size = 1024 * max_file_size_kib
         if data:
-            contenttype = mimetypes.guess_type(data.name)[0] # don't rely on the browser: data.content_type could be wrong or empty
+            contenttype = guess_mime_type(data.name) # don't rely on the browser: data.content_type could be wrong or empty
             if contenttype.startswith("text"):
                 content = data.read()
                 # undo the consuming the read method has done
@@ -49,9 +45,9 @@ class SolutionFileForm(ModelForm):
                         raise forms.ValidationError(_('The zip file is too big.'))
                     for fileinfo in zip.infolist():
                         filename = fileinfo.filename
-                        (type, encoding) = mimetypes.guess_type(filename)
+                        mime_type = guess_mime_type(filename)
                         ignorred = SolutionFile.ignorred_file_names_re.search(filename)
-                        is_text_file = not ignorred and type and type.startswith("text")
+                        is_text_file = not ignorred and mime_type and mime_type.startswith("text")
                         if is_text_file and contains_NUL_char(zip.read(filename)):
                             raise forms.ValidationError(_("The plain text file '%(file)s' in this zip file contains a NUL character, which is not supported." %{'file':filename}))
                         # check whole zip instead of contained files

--- a/src/solutions/models.py
+++ b/src/solutions/models.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 import zipfile
 import tempfile
-import mimetypes
 import shutil
 import os, re
 
@@ -22,11 +21,8 @@ from django.core.mail import EmailMessage
 
 from accounts.models import User
 from utilities import encoding, file_operations
+from utilities.mimetypes import guess_mime_type_with_fallback as guess_mime_type
 from configuration import get_settings
-
-# TODO: This is duplicated from solutions/forms.py. Where should this go?
-for (mimetype, extension) in settings.MIMETYPE_ADDITIONAL_EXTENSIONS:
-    mimetypes.add_type(mimetype, extension, strict=True)
 
 class Solution(models.Model):
     """ """
@@ -149,7 +145,7 @@ class SolutionFile(models.Model):
                     zip_file_name = zip_file_name  if isinstance(zip_file_name, str) else str(zip_file_name, errors='replace')
                     new_solution_file.file.save(zip_file_name, File(temp_file), save=True)        # need to check for filenames begining with / or ..?
         else:
-            self.mime_type = mimetypes.guess_type(self.file.name)[0]
+            self.mime_type = guess_mime_type(self.file.name)
             models.Model.save(self, force_insert, force_update, using)
 
     def __str__(self):

--- a/src/utilities/mimetypes.py
+++ b/src/utilities/mimetypes.py
@@ -1,0 +1,11 @@
+from django.conf import settings
+import mimetypes
+
+for (mimetype, extension) in settings.MIMETYPE_ADDITIONAL_EXTENSIONS:
+    mimetypes.add_type(mimetype, extension, strict=True)
+
+def guess_mime_type_with_fallback(filename):
+    content_type = mimetypes.guess_type(filename)[0]
+    if content_type is None:
+        return 'application/octet-stream'
+    return content_type


### PR DESCRIPTION
While we removed the MIME type check for a task in #38, the MIME types still need to be looked up for all the files that were uploaded. If a MIME type was unknown previously, you would have gotten an error message telling you so. This is no longer the case. As we don't want to deal with MIME types any longer (at least not from a user perspective), it makes sense to add a fallback in case there is no known MIME type for some file. I think `application/octet-stream` should be the correct type in that case.