### PR TITLE
Revert "Update Pygments to 2.16.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ sqlparse
 Django~=2.2;python_version>="3.5"
 # M2Crypto # has been removed by commit "use hashlib+smime for upload verification mails instead of M2Crypto" (19.1.2018)
 Markdown
+# Warning: updating Pygments currently breaks the syntax highlighting for annotated solution files.
+# DO NOT UPDATE YET!
 Pygments~=2.7.0;python_version>="3.4"
 chardet
 django-extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ sqlparse
 Django~=2.2;python_version>="3.5"
 # M2Crypto # has been removed by commit "use hashlib+smime for upload verification mails instead of M2Crypto" (19.1.2018)
 Markdown
-Pygments~=2.16.1
+Pygments~=2.7.0;python_version>="3.4"
 chardet
 django-extensions
 


### PR DESCRIPTION
This reverts commit 8fd9243b6809bbf0cc581d0d0363f2a56a3bc2b6 to and resolves the most of the issues with displaying the annotated solution files. There are still some minor things that don't look quite right. But I'd bet that this was already present previously. At least, the output should be readable again.