### PR TITLE
Add a button to save and publish an attestation

### DIFF
--- a/src/templates/attestation/attestation_edit.html
+++ b/src/templates/attestation/attestation_edit.html
@@ -89,7 +89,8 @@
 <form enctype="multipart/form-data" method="post" action="">{% csrf_token %}
 
 <div id="form_actions">
-	<input type="submit" value="Save/Preview"/ id="id_save">
+	<input type="submit" value="Save/Publish" name="publish">
+	<input type="submit" value="Save/Preview" name="save">
 	<input type="button" value="Discard/Back" onClick="parent.location='{% url "attestation_list" solution.task_id %}'">
 </div>
 


### PR DESCRIPTION
As this is a button intended to save us two additional clicks, I did not add a confirmation dialog for this button. That way, it actually is a shortcut for publishing an attestation. If you'd still like to have a confirmation dialog, let me know.

Closes #10