### PR TITLE
Fix appearance of unnecessary confirmation dialog

### DIFF
--- a/src/templates/attestation/attestation_edit.html
+++ b/src/templates/attestation/attestation_edit.html
@@ -90,7 +90,7 @@
 
 <div id="form_actions">
 	<input type="submit" value="Save/Publish" name="publish">
-	<input type="submit" value="Save/Preview" name="save">
+	<input type="submit" value="Save/Preview" name="save" id="id_save">
 	<input type="button" value="Discard/Back" onClick="parent.location='{% url "attestation_list" solution.task_id %}'">
 </div>
 


### PR DESCRIPTION
The confirmation dialog would be shown when trying to Save/Preview an attestation. This is a bug/regression introduced with commit 2beecfb62f2e5f5d0c9ef6809aa58cc85073a8f7. Skipping this confirmation is definitely more useful. The attestation won't immediately be published anyway. This is restoring the old behavior of the "Save/Preview" button.

The id of the input is referenced from the file `media/scripts/confirm_close.js`. I excluded the media directory by mistake when I was searching for the usage of the id previously.