### PR TITLE
Add option to discard safe-docker artefacts

### DIFF
--- a/scripts/safe-docker
+++ b/scripts/safe-docker
@@ -17,6 +17,7 @@ my $writable = "";
 my $no_uid_mod = "";
 my $external_dir = "";
 my $host_net = "";
+my $discard_artefacts = "";
 
 GetOptions (
 	"image=s" => \$image,
@@ -28,6 +29,7 @@ GetOptions (
 	"no-uid-mod" => \$no_uid_mod,
 	"external=s" => \$external_dir,
 	"host-net" => \$host_net,
+	"discard-artefacts" => \$discard_artefacts,
 )
 or die("Error in command line arguments\n");
 
@@ -109,7 +111,9 @@ sub clean_and_exit {
 		my $helpername = %$volume_entry{"container"};
 		my $dir = %$volume_entry{"dir"};
 		my $volumename = %$volume_entry{"volume"};
-		run ["docker", "cp", "${helpername}:${dir}.", $dir], \undef, '>/dev/null';
+		if ($discard_artefacts ne "1") {
+			run ["docker", "cp", "${helpername}:${dir}.", $dir], \undef, '>/dev/null';
+		}
 		run ["docker", "container", "rm", $helpername], \undef, '>/dev/null';
 		run ["docker", "volume", "rm", $volumename], \undef, '>/dev/null';
 	}

--- a/src/settings/defaults.py
+++ b/src/settings/defaults.py
@@ -327,6 +327,10 @@ def load_defaults(settings):
     # When this is set to false, the container does not have any access to the network.
     d.DOCKER_CONTAINER_HOST_NET = False
 
+    # If the altered files should not be copied back into the sandbox directory
+    # after running a check with safe-docker.
+    d.DOCKER_DISCARD_ARTEFACTS = False
+
 
     # be sure that you change file permission
     # sudo chown praktomat:tester praktomat/src/checker/scripts/java

--- a/src/utilities/safeexec.py
+++ b/src/utilities/safeexec.py
@@ -93,6 +93,8 @@ def execute_arglist(args, working_directory, environment_variables={}, timeout=N
         # Add specified external directory
         if settings.DOCKER_CONTAINER_EXTERNAL_DIR is not None:
             command += ["--external", settings.DOCKER_CONTAINER_EXTERNAL_DIR]
+        if settings.DOCKER_DISCARD_ARTEFACTS:
+            command += ["--discard-artefacts"]
         command += ["--"]
         # add environment
         command += ["env"]


### PR DESCRIPTION
With this setting enabled, files generated with a checker (and safe-docker) won't be copied back to the host. This fixes #26.

The reason that we can't just run the cleanup under Docker is that this would need to happen after all the checkers have been run. But because we don't (and can't) bind mount the sandbox directory, we're copying the files into a volume, run the checker with that volume mounted and copy the files back from the volume to the host afterwards. With an extra Docker cleanup, the files would already be owned by root. When we're deleting them inside the container and then copying the results back, nothing is copied back because there is no file left in the volume and the old files (owned by root) continue to exist.
For that reason, my suggested approach might just be the more practical solution for now.