### PR TITLE
Fix log truncation

### DIFF
--- a/src/checker/basemodels.py
+++ b/src/checker/basemodels.py
@@ -195,7 +195,7 @@ def truncated_log(log):
     log_length = len(log)
     if log_length > settings.TEST_MAXLOGSIZE*1024:
         # since we might be truncating utf8 encoded strings here, result may be erroneous, so we explicitly replace faulty byte tokens
-        return (force_text('======= Warning: Output too long, hence truncated ======\n' + log[0:(settings.TEST_MAXLOGSIZE*1024)/2] + "\n...\n...\n...\n...\n" + log[log_length-((settings.TEST_MAXLOGSIZE*1024)/2):], errors='replace'), True)
+        return (force_text('======= Warning: Output too long, hence truncated ======\n' + log[0:(settings.TEST_MAXLOGSIZE*1024)//2] + "\n...\n...\n...\n...\n" + log[log_length-((settings.TEST_MAXLOGSIZE*1024)//2):], errors='replace'), True)
     return (log, False)
 
 


### PR DESCRIPTION
Right now, this function throws a type error when a log has to be truncated because we're trying to index a list using a float. This bug seemed to slip through, back when the Praktomat was updated for Python 3.