### PR TITLE
Set initial deadline tolerance to 0

### DIFF
--- a/src/configuration/migrations/0017_fix_initial_deadline_tolerance.py
+++ b/src/configuration/migrations/0017_fix_initial_deadline_tolerance.py
@@ -1,0 +1,19 @@
+from datetime import timedelta
+from django.db import migrations, models
+
+def disable_deadline_tolerance(apps, schema_editor):
+    Settings = apps.get_model("configuration", "Settings")
+    conf = Settings.objects.get(id=1)
+    conf.deadline_tolerance = timedelta(hours=0)
+    conf.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('configuration', '0016_remove_settings_hide_solutions_of_expired_tasks'),
+    ]
+
+    operations = [
+        migrations.RunPython(disable_deadline_tolerance),
+    ]

--- a/src/hbrs_tests/test_CUnitCppUnit_Checker.py
+++ b/src/hbrs_tests/test_CUnitCppUnit_Checker.py
@@ -74,8 +74,8 @@ class ModelCUnitCppUnitCheckerTests(TestCase):
             ratingScaleItem.save()
             # modify publication and submission date
             task = Task.objects.get(pk=taskID)
-            from datetime import datetime
-            task.submission_date=datetime.now()
+            from datetime import datetime, timedelta
+            task.submission_date=datetime.now() + timedelta(minutes=60)
             task.publication_date=datetime.now()
             task.final_grade_rating_scale=ratingScale
             task.save()


### PR DESCRIPTION
This is a breaking change. Existing instances will be changed to have a deadline tolerance of 0 hours. You need to set your desired deadline tolerance again after applying this migration (if it is not 0).

This should have been part of 99e9da8908b3151b402012e43858efcb147c363c. But I didn't know that this is required back then...

Maybe, it would also be possible to alter the old migration to prevent that this is breaking instances with a non-zero deadline tolerance. But I'm not feeling too confident about fiddling around with already applied migrations...

Closes #40