### PR TITLE
Sort file tabs by basename

### DIFF
--- a/src/solutions/templatetags/tasks_extras.py
+++ b/src/solutions/templatetags/tasks_extras.py
@@ -1,4 +1,5 @@
 from django import template
+import os
 
 register = template.Library()
 
@@ -9,3 +10,17 @@ def uploadsleft(value, arg):
 	return left
 
 register.filter('uploadsleft', uploadsleft)
+
+# This is a modified version of Django's built-in dictsort filter
+def basenamedictsort(value, arg):
+	parts = arg.split('.')
+	def nested_basename(value):
+		for part in parts:
+			try:
+				value = value[part]
+			except (AttributeError, IndexError, KeyError, TypeError, ValueError):
+				value = getattr(value, part)
+		return os.path.basename(value)
+	return sorted(value, key=nested_basename)
+
+register.filter('basenamedictsort', basenamedictsort)

--- a/src/templates/attestation/attestation_edit.html
+++ b/src/templates/attestation/attestation_edit.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load tasks_extras %}
 {% block extrahead %}{{ block.super }}
 	<script type="text/javascript" src="{{STATIC_URL}}frameworks/jquery/jquery.Storage.js"></script>
 	<script type="text/javascript" src="{{STATIC_URL}}script/solution_inlines.js"></script>
@@ -185,7 +186,7 @@
 			{% with attestFileFormSet.get_queryset.all as solutionfiles %}
 				<div class="anntabs">
 					<ul>
-						{% for solutionfile in solutionfiles %}
+						{% for solutionfile in solutionfiles|basenamedictsort:"solution_file.file.name" %}
 							<li><a href="#editor" data-solutionfileid="{{solutionfile.pk}}">{{solutionfile}}</a></li>
 						{%endfor%}
 					</ul>

--- a/src/templates/attestation/attestation_view.html
+++ b/src/templates/attestation/attestation_view.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load highlight %}{% load i18n  %}
+{% load tasks_extras %}
 {% block extrahead %}{{ block.super }}
 	<script type="text/javascript" src="{{STATIC_URL}}/frameworks/jquery.easy-confirm-dialog/jquery.easy-confirm-dialog.js"></script>
 	<script type="text/javascript" src="{{STATIC_URL}}script/solution_inlines.js"></script>
@@ -93,12 +94,12 @@
 <h2>{% trans "Annotated Files" %}</h2>
 <div class="filetabs">
 	<ul>
-		{% for anotfile in attest.annotatedsolutionfile_set.all%}
+		{% for anotfile in attest.annotatedsolutionfile_set.all|basenamedictsort:"solution_file.file.name" %}
 			<li><a href="#file{{forloop.counter}}">{{anotfile}}{% if anotfile.has_anotations%}<span class="has_anotations">*</span>{% endif %}</a></li>
 		{%endfor%}
 	</ul>
 
-	{% for anotfile in attest.annotatedsolutionfile_set.all%}
+	{% for anotfile in attest.annotatedsolutionfile_set.all|basenamedictsort:"solution_file.file.name" %}
 		<div class="file" id="file{{forloop.counter}}">
 			<h3>{{solutionfile}}</h3>
 			<div class="content">{{anotfile.content_diff|highlight_table:anotfile.solution_file.file.name|highlight_diff}}</div>

--- a/src/templates/solutions/solution_files_inline.html
+++ b/src/templates/solutions/solution_files_inline.html
@@ -6,14 +6,15 @@
 
 
 {% load highlight %}
+{% load tasks_extras %}
 <div class="filetabs">
 	<ul>
-		{% for solutionfile in solutionfiles %}
+		{% for solutionfile in solutionfiles|basenamedictsort:"file.name" %}
 			<li><a href="#file{{forloop.counter}}">{{solutionfile}}</a></li>
 		{%endfor%}
 	</ul>
 
-	{% for solutionfile in solutionfiles%}
+	{% for solutionfile in solutionfiles|basenamedictsort:"file.name" %}
 		<div class="file" id="file{{forloop.counter}}">
       <h3>{{solutionfile}}</h3>
       <div class="download">


### PR DESCRIPTION
This sorts the file tabs for both the solution and the attestation view. The sorting is case sensitive. If you'd rather like it to be case insensitive, let me know.

Also, I'm not sure if tasks_extras is the right place for the basenamedictsort filter. But for now, it should do...

Closes #56