### PR TITLE
Fix solution download for users

### DIFF
--- a/src/solutions/views.py
+++ b/src/solutions/views.py
@@ -268,7 +268,7 @@ def solution_download(request, solution_id, include_checker_files, include_artif
     solution = get_object_or_404(Solution, pk=solution_id)
     allowed_tutor = request.user.is_tutor and solution.author.tutorial in request.user.tutored_tutorials.all()
     allowed_user = solution.author == request.user and not include_checker_files and not include_artifacts
-    hide = request.user.is_user and solution.task.should_hid(request.user)
+    hide = request.user.is_user and solution.task.should_hide(request.user)
     if not (request.user.is_superuser or request.user.is_trainer or allowed_tutor or allowed_user) or hide:
         return access_denied(request)
 


### PR DESCRIPTION
The solution download for users is currently broken because of a little typo that slipped through in an earlier commit. This should be the required fix.