### PR TITLE
Also hide confirmation dialog on "Save/Publish"

### DIFF
--- a/media/script/confirm_close.js
+++ b/media/script/confirm_close.js
@@ -7,6 +7,6 @@ $(window).load(function () {
 	$('#id_attest-public_comment').change(function(){somethingWasChanged=true;});
 	$('#id_attest-private_comment').change(function(){somethingWasChanged=true;});
 	$('#id_attest-final_grade').change(function(){somethingWasChanged=true;});
-	$('#id_save').click(function(){somethingWasChanged=false;});
+	$('.save_btn').click(function(){somethingWasChanged=false;});
 });
 

--- a/src/templates/attestation/attestation_edit.html
+++ b/src/templates/attestation/attestation_edit.html
@@ -90,8 +90,8 @@
 <form enctype="multipart/form-data" method="post" action="">{% csrf_token %}
 
 <div id="form_actions">
-	<input type="submit" value="Save/Publish" name="publish">
-	<input type="submit" value="Save/Preview" name="save" id="id_save">
+	<input type="submit" value="Save/Publish" name="publish" class="save_btn">
+	<input type="submit" value="Save/Preview" name="save" class="save_btn">
 	<input type="button" value="Discard/Back" onClick="parent.location='{% url "attestation_list" solution.task_id %}'">
 </div>
 


### PR DESCRIPTION
This hides the confirmation dialog appearing when clicking "Save/Publish" for an edited attestation.