### PR TITLE
Remove explicit dependency on sqlparse

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 urllib3[secure]
-# workaround for debug-toolbar/sqlparse incompatibility, see http://stackoverflow.com/questions/38479063/django-debug-toolbar-breaking-on-admin-while-getting-sql-stats
-sqlparse
 Django~=2.2;python_version>="3.5"
 # M2Crypto # has been removed by commit "use hashlib+smime for upload verification mails instead of M2Crypto" (19.1.2018)
 Markdown


### PR DESCRIPTION
`sqlparse` is still a dependency of Django. However, we don't use it directly in our code. The only reason this was listed as an explicit dependency was an incompatibility many years ago where an old version was required.