### PR TITLE
Update GitHub Actions to use Node.js 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -24,7 +24,7 @@ jobs:
         sudo apt-get install r-base wget
         sudo apt-get install libcunit1-dev libcppunit-dev
         sudo apt-get install apache2-dev  # needed for unit test of praktomat.wsgi , praktomat.wsgi used mod_wsgi, installing mod_wsgi via requirementsfile via pip needs apache2-dev
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
         miniconda-version: latest


### PR DESCRIPTION
Both the checkout as well as the setup-miniconda action were using and old version of Node.js. GitHub is already forcing the actions to run on Node.js 20. Besides getting bugfixes and whatnot, the new versions remove the warning as the actions are then updated to run on Node.js 20 by themselves.