### PR TITLE
Allow omitting the custom task ID

### DIFF
--- a/src/utilities/safeexec.py
+++ b/src/utilities/safeexec.py
@@ -228,9 +228,10 @@ def safe_docker(environment_variables, extra_dirs, maxmem, ulimits, working_dire
     if settings.DOCKER_CONTAINER_EXTERNAL_DIR is not None:
         external_dir = None
         tmpl = string.Template(settings.DOCKER_CONTAINER_EXTERNAL_DIR)
-        requires_task_id_custom = "TASK_ID_CUSTOM" in tmpl.get_identifiers()
+        var_id = "TASK_ID_CUSTOM"
+        requires_task_id_custom = var_id in tmpl.get_identifiers()
         if requires_task_id_custom:
-            task_id_custom = environment_variables.get('TASK_ID_CUSTOM')
+            task_id_custom = environment_variables.get(var_id)
             if task_id_custom is not None and task_id_custom != "":
                 external_dir = string.Template(settings.DOCKER_CONTAINER_EXTERNAL_DIR).substitute(TASK_ID_CUSTOM=task_id_custom)
         else:

--- a/src/utilities/safeexec.py
+++ b/src/utilities/safeexec.py
@@ -226,11 +226,17 @@ def safe_docker(environment_variables, extra_dirs, maxmem, ulimits, working_dire
         cmd += add_dir(d, True, volumes)
 
     if settings.DOCKER_CONTAINER_EXTERNAL_DIR is not None:
-        external_dir = settings.DOCKER_CONTAINER_EXTERNAL_DIR
-        task_id_custom = environment_variables.get('TASK_ID_CUSTOM')
-        if task_id_custom is not None and task_id_custom != "":
-            external_dir = string.Template(settings.DOCKER_CONTAINER_EXTERNAL_DIR).substitute(TASK_ID_CUSTOM=environment_variables.get('TASK_ID_CUSTOM'))
-        cmd += [f"--volume={external_dir}:/external:ro"]
+        external_dir = None
+        tmpl = string.Template(settings.DOCKER_CONTAINER_EXTERNAL_DIR)
+        requires_task_id_custom = "TASK_ID_CUSTOM" in tmpl.get_identifiers()
+        if requires_task_id_custom:
+            task_id_custom = environment_variables.get('TASK_ID_CUSTOM')
+            if task_id_custom is not None and task_id_custom != "":
+                external_dir = string.Template(settings.DOCKER_CONTAINER_EXTERNAL_DIR).substitute(TASK_ID_CUSTOM=task_id_custom)
+        else:
+            external_dir = settings.DOCKER_CONTAINER_EXTERNAL_DIR
+        if external_dir is not None:
+            cmd += [f"--volume={external_dir}:/external:ro"]
     
     cmd += add_dir(working_directory, False, volumes)
     cmd += [f"--workdir={working_directory}"]


### PR DESCRIPTION
If an external directory contains a TASK_ID_CUSTOM variable that needs to be replaced but no custom task ID is present, the external directory will not be mounted. This allows having tasks that don't need an external directory mounted (and have no fitting directory to mount) while still being able to have other tasks that require an external directory to be mounted.