### PR TITLE
Pass with a warning if the log is truncated

### DIFF
--- a/src/checker/checker/CUnitChecker_v2.py
+++ b/src/checker/checker/CUnitChecker_v2.py
@@ -386,7 +386,8 @@ class CUnitChecker2(CheckerWithFile):
 
 
         result.set_log(output,timed_out=timed_out or oom_ed,truncated=truncated,oom_ed=oom_ed)
-        result.set_passed(not exitcode and not timed_out and not oom_ed and self.output_ok(output) and not truncated)
+        result.set_passed(not exitcode and not timed_out and not oom_ed and self.output_ok(output))
+        result.set_passed_with_warning(result.passed and truncated)
         result.save()
 
         return result

--- a/src/checker/checker/HaskellTestFrameWorkChecker.py
+++ b/src/checker/checker/HaskellTestFrameWorkChecker.py
@@ -124,7 +124,8 @@ class HaskellTestFrameWorkChecker(CheckerWithFile):
 
 
         result.set_log(output, timed_out=timed_out or oom_ed, truncated=truncated)
-        result.set_passed(not exitcode and not timed_out and not oom_ed and self.output_ok(output) and not truncated)
+        result.set_passed(not exitcode and not timed_out and not oom_ed and self.output_ok(output))
+        result.set_passed_with_warning(result.passed and truncated)
         return result
 
 class HaskellTestFrameWorkCheckerInline(CheckerInline):

--- a/src/checker/checker/JUnitChecker.py
+++ b/src/checker/checker/JUnitChecker.py
@@ -96,7 +96,8 @@ class JUnitChecker(Checker):
 
 
         result.set_log(output, timed_out=timed_out or oom_ed, truncated=truncated, oom_ed=oom_ed)
-        result.set_passed(not exitcode and not timed_out and not oom_ed and self.output_ok(output) and not truncated)
+        result.set_passed(not exitcode and not timed_out and not oom_ed and self.output_ok(output))
+        result.set_passed_with_warning(result.passed and truncated)
         return result
 
 #class JUnitCheckerForm(AlwaysChangedModelForm):

--- a/src/checker/checker/JavaChecker.py
+++ b/src/checker/checker/JavaChecker.py
@@ -70,7 +70,8 @@ class JavaChecker(Checker):
         output = output.replace("WARNING: A command line option has enabled the Security Manager\n","")
         output = output.replace("WARNING: The Security Manager is deprecated and will be removed in a future release\n","")
         result.set_log(output, timed_out=timed_out or oom_ed, truncated=truncated, oom_ed=oom_ed)
-        result.set_passed(not exitcode and not timed_out and not oom_ed and self.output_ok(output) and not truncated)
+        result.set_passed(not exitcode and not timed_out and not oom_ed and self.output_ok(output))
+        result.set_passed_with_warning(result.passed and truncated)
         return result
 
 

--- a/src/checker/checker/ScriptChecker.py
+++ b/src/checker/checker/ScriptChecker.py
@@ -100,8 +100,8 @@ class ScriptChecker(Checker):
         result.set_log(output, timed_out=timed_out, truncated=truncated, oom_ed=oom_ed)
 
         exitcode_ok = exitcode == 0 or exitcode == EXIT_CODE_PASSED_WITH_WARNING
-        result.set_passed(exitcode_ok and not timed_out and not oom_ed and not truncated)
-        result.set_passed_with_warning(result.passed and exitcode == EXIT_CODE_PASSED_WITH_WARNING)
+        result.set_passed(exitcode_ok and not timed_out and not oom_ed)
+        result.set_passed_with_warning(result.passed and (exitcode == EXIT_CODE_PASSED_WITH_WARNING or truncated))
 
         return result
 


### PR DESCRIPTION
I don't think that a truncated log should result in a rejected solution. A warning should be enough.