### PR TITLE
Admin: Enable manual solution uploads and 'Final' status management

### DIFF
--- a/src/solutions/admin.py
+++ b/src/solutions/admin.py
@@ -22,7 +22,8 @@ class SolutionFileInline(admin.TabularInline):
     model = SolutionFile
     extra = 0
     can_delete = False
-    readonly_fields=["mime_type", "file"]
+    fields = ["file", "mime_type"]
+    readonly_fields=["mime_type"]
 
 
 class IsLatestOfOnlyFailedFilter(admin.SimpleListFilter):
@@ -84,11 +85,18 @@ class SolutionAdmin(admin.ModelAdmin):
     list_display = ["edit", "view_url", "download_url", "run_checker_url", "task", "show_author", "number", "creation_date", "final", "accepted", "tests_failed", "all_checker_finished", "latest_of_only_failed", "plagiarism"]
     list_filter = ["task", "author", "author__groups", "creation_date" , IsLatestOfOnlyFailedFilter ,"final", "accepted", "warnings", "plagiarism"]
     fieldsets = ((None, {
-                    'fields': ( "task", "show_author", "creation_date", ("final", "accepted", "warnings", "all_checker_finished"), "plagiarism", 'useful_links')
+                    'fields': ( "task", "author", "creation_date", ("final", "accepted", "warnings", "all_checker_finished"), "plagiarism", 'useful_links')
                 }),)
-    readonly_fields=["task", "show_author", "creation_date", "accepted", "final", "all_checker_finished", "tests_failed", 'useful_links']
-    inlines =  [CheckerResultInline, SolutionFileInline]
+    readonly_fields = ["creation_date", "accepted", "all_checker_finished", "tests_failed", 'useful_links']
+    inlines = [CheckerResultInline, SolutionFileInline]
     actions = ['run_checkers', 'run_checkers_all', 'mark_plagiarism', 'mark_no_plagiarism']
+
+    def get_readonly_fields(self, request, obj=None):
+        # If obj exists (Edit mode), make task and author readonly
+        if obj:
+            return self.readonly_fields + ["task", "author"]
+        # On creation (obj=None), all fields defined in fieldsets are editable
+        return self.readonly_fields
 
     #for sorting computed values "tests_failed" and "latest of only failed" which are not stored in database,
     #wie have to implement the behavior of get_queryset to simulate a return of SQL's ORDER BY


### PR DESCRIPTION
**Summary**
This PR enhances the Django Admin interface for Solutions, allowing administrators to manually upload code on behalf of students and manage the "Final" status of submissions.

**The Problem**
In our current Praktomat instance, we encountered cases where students' submissions were not automatically marked as `FINAL`, even if it was their only submission for a task (see screenshot). This prevents the submission from being properly graded. Additionally, admins previously had no way to manually intervene if a student had technical difficulties uploading their own code.
<img width="1209" height="436" alt="solution" src="https://github.com/user-attachments/assets/0de9fd6b-4484-4252-9cf2-3c068e6f55b3" />

**Suspected Root Cause for Missing Final State**
I suspect this inconsistency occurred after we updated certain tests retroactively and re-ran them for all submissions. While the re-runs were successful and submissions passed, the logic that assigns the `FINAL` flag seems to have been disrupted for a small subset of students. As I am currently unable to reproduce this behavior and it only affects a few isolated cases, I believe the most efficient solution is to provide admins with the ability to manually correct these specific entries.


